### PR TITLE
Rename library to meshup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,16 +33,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
-name = "io3d_core"
-version = "0.1.0"
-dependencies = [
- "ndarray",
- "numpy",
- "pyo3",
- "thiserror",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +65,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "meshup"
+version = "0.1.0"
+dependencies = [
+ "ndarray",
+ "numpy",
+ "pyo3",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "io3d_core"
+name = "meshup"
 version = "0.1.0"
 edition = "2021"
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 io3d developers
+Copyright (c) 2024 meshup developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# io3d 
+# meshup
 
 This repository provides a Rust library with Python bindings for converting elevation rasters to triangle meshes. The library exposes functions to build a mesh and export it to the PLY format for use in Blender or other tools.
 

--- a/examples/basic_terrain.py
+++ b/examples/basic_terrain.py
@@ -1,5 +1,5 @@
 import rasterio
-from io3d import raster_to_mesh, export_ply
+from meshup import raster_to_mesh, export_ply
 
 # Path to the DEM file
 path = "data/squamish.tif"

--- a/examples/basic_terrain_color.py
+++ b/examples/basic_terrain_color.py
@@ -1,5 +1,5 @@
 import rasterio
-from io3d import raster_to_mesh_styled_py, export_ply
+from meshup import raster_to_mesh_styled_py, export_ply
 
 # Path to the DEM file
 path = "data/dem_world_cover.tif"

--- a/examples/dem_ndsi_to_ply.py
+++ b/examples/dem_ndsi_to_ply.py
@@ -1,6 +1,6 @@
 import rasterio
 import numpy as np
-from io3d import raster_to_mesh_styled_py, export_ply
+from meshup import raster_to_mesh_styled_py, export_ply
 
 """Example converting `dem_ndsi.tif` with two NDSI layers to a mesh."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=1.2,<2.0"]
 build-backend = "maturin"
 
 [project]
-name = "io3d"
+name = "meshup"
 version = "0.1.0"
 requires-python = ">=3.8"
 dependencies = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ fn export_ply(mesh: &Mesh, path: &str) -> PyResult<()> {
 }
 
 #[pymodule]
-fn io3d(_py: Python, m: &PyModule) -> PyResult<()> {
+fn meshup(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Vertex>()?;
     m.add_class::<Face>()?;
     m.add_class::<Mesh>()?;

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,5 @@
 import numpy as np
-from io3d import raster_to_mesh, raster_to_mesh_styled_py
+from meshup import raster_to_mesh, raster_to_mesh_styled_py
 
 
 def test_raster_to_mesh_simple():


### PR DESCRIPTION
## Summary
- rename project and Python module to `meshup`
- update crate name in Cargo.toml and Cargo.lock
- adjust examples, tests, and docs to new name
- update license reference

## Testing
- `maturin develop --release`
- `pytest -q` *(fails: AttributeError: 'Vertex' object has no attribute 'r')*

------
https://chatgpt.com/codex/tasks/task_e_685afa15772483339874d461298527df