### PR TITLE
Remove _py suffix

### DIFF
--- a/examples/basic_terrain_color.py
+++ b/examples/basic_terrain_color.py
@@ -1,5 +1,5 @@
 import rasterio
-from meshup import raster_to_mesh_styled_py, export_ply
+from meshup import raster_to_mesh_styled, export_ply
 
 # Path to the DEM file
 path = "data/dem_world_cover.tif"
@@ -40,5 +40,5 @@ style = {
     "overlays": [],
 }
 
-mesh = raster_to_mesh_styled_py(elev, style, landcover, None)
+mesh = raster_to_mesh_styled(elev, style, landcover, None)
 export_ply(mesh, "squamish_color.ply")

--- a/examples/dem_ndsi_to_ply.py
+++ b/examples/dem_ndsi_to_ply.py
@@ -1,6 +1,6 @@
 import rasterio
 import numpy as np
-from meshup import raster_to_mesh_styled_py, export_ply
+from meshup import raster_to_mesh_styled, export_ply
 
 """Example converting `dem_ndsi.tif` with two NDSI layers to a mesh."""
 
@@ -36,6 +36,6 @@ style = {
 }
 
 overlays = np.stack([ndsi_may, ndsi_june], axis=0)
-mesh = raster_to_mesh_styled_py(elevation, style, None, overlays)
+mesh = raster_to_mesh_styled(elevation, style, None, overlays)
 export_ply(mesh, "dem_ndsi.ply")
 print("Wrote dem_ndsi.ply")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,10 @@ mod tests;
 pub use crate::mesh::{Vertex, Face, Mesh, MeshFrame};
 pub use crate::style::{ColorRamp, StyleSpec};
 use crate::export::export_ply as export_ply_rs;
-use crate::convert::{raster_to_mesh as raster_to_mesh_rs, raster_to_mesh_styled};
+use crate::convert::{
+    raster_to_mesh as raster_to_mesh_rs,
+    raster_to_mesh_styled as raster_to_mesh_styled_rs,
+};
 
 #[pyfunction]
 fn raster_to_mesh(
@@ -22,13 +25,13 @@ fn raster_to_mesh(
 }
 
 #[pyfunction(signature = (elevation, style, base=None, overlays=None))]
-fn raster_to_mesh_styled_py(
+fn raster_to_mesh_styled(
     elevation: &PyArray2<f32>,
     style: &pyo3::types::PyDict,
     base: Option<&PyArray2<f32>>,
     overlays: Option<&numpy::PyArray3<f32>>,
 ) -> PyResult<Mesh> {
-    raster_to_mesh_styled(elevation, style, base, overlays)
+    raster_to_mesh_styled_rs(elevation, style, base, overlays)
 }
 
 #[pyfunction]
@@ -45,7 +48,7 @@ fn meshup(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<ColorRamp>()?;
     m.add_class::<StyleSpec>()?;
     m.add_function(wrap_pyfunction!(raster_to_mesh, m)?)?;
-    m.add_function(wrap_pyfunction!(raster_to_mesh_styled_py, m)?)?;
+    m.add_function(wrap_pyfunction!(raster_to_mesh_styled, m)?)?;
     m.add_function(wrap_pyfunction!(export_ply, m)?)?;
     Ok(())
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,5 @@
 import numpy as np
-from meshup import raster_to_mesh, raster_to_mesh_styled_py
+from meshup import raster_to_mesh, raster_to_mesh_styled
 
 
 def test_raster_to_mesh_simple():


### PR DESCRIPTION
## Summary
- rename `raster_to_mesh_styled_py` binding to `raster_to_mesh_styled`
- update examples and tests

## Testing
- `cargo test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685afcd90fe083339c30171faab15a44