### PR TITLE
fix multi-frame ply

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,7 @@ python examples/dem_ndsi_to_ply.py  # elevation + two NDSI overlay frames
 ```
 
 Both scripts produce ``.ply`` files that can be imported into Blender with
-vertex colors. The land cover values are rounded to the nearest integer so
-slightly off floating-point values map correctly to the style table.
+vertex colors. When multiple time steps are present, the writer now includes
+RGB triples for each frame (`red_0`, `green_0`, `blue_0`, ...). The land cover
+values are rounded to the nearest integer so slightly off floating-point values
+map correctly to the style table.

--- a/src/export.rs
+++ b/src/export.rs
@@ -12,16 +12,39 @@ pub fn export_ply(mesh: &Mesh, path: &str) -> Result<()> {
     writeln!(file, "property float x")?;
     writeln!(file, "property float y")?;
     writeln!(file, "property float z")?;
-    writeln!(file, "property uchar red")?;
-    writeln!(file, "property uchar green")?;
-    writeln!(file, "property uchar blue")?;
+    let frame_count = mesh
+        .vertices
+        .first()
+        .map(|v| v.colors.len())
+        .unwrap_or(0);
+    for t in 0..frame_count.max(1) {
+        if frame_count <= 1 {
+            writeln!(file, "property uchar red")?;
+            writeln!(file, "property uchar green")?;
+            writeln!(file, "property uchar blue")?;
+        } else {
+            writeln!(file, "property uchar red_{}", t)?;
+            writeln!(file, "property uchar green_{}", t)?;
+            writeln!(file, "property uchar blue_{}", t)?;
+        }
+    }
     writeln!(file, "element face {}", mesh.faces.len())?;
     writeln!(file, "property list uchar int vertex_indices")?;
     writeln!(file, "end_header")?;
 
     for v in &mesh.vertices {
-        let color = v.colors.get(0).copied().unwrap_or([255, 255, 255]);
-        writeln!(file, "{} {} {} {} {} {}", v.x, v.y, v.z, color[0], color[1], color[2])?;
+        let mut line = format!("{} {} {}", v.x, v.y, v.z);
+        if v.colors.is_empty() {
+            line.push_str(" 255 255 255");
+        } else if v.colors.len() == 1 {
+            let c = v.colors[0];
+            line.push_str(&format!(" {} {} {}", c[0], c[1], c[2]));
+        } else {
+            for c in &v.colors {
+                line.push_str(&format!(" {} {} {}", c[0], c[1], c[2]));
+            }
+        }
+        writeln!(file, "{}", line)?;
     }
 
     for f in &mesh.faces {


### PR DESCRIPTION
### what i changed
- updated `export_ply` to write all color frames
- documented new frame properties in README

### how to test it
- `cargo test --quiet`
- `source .venv/bin/activate && pytest -q`

### other notes
- n/a

------
https://chatgpt.com/codex/tasks/task_e_685b0cb0313c8333bf03f7569521f8a8